### PR TITLE
Update SDK version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "facebook/facebook-instant-articles-sdk-php": "^1.5",
+        "facebook/facebook-instant-articles-sdk-php": "^1.6.2",
         "mihaeu/html-formatter": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2e42ee2cbaae81e1fd39d9144c6bb0e0",
-    "content-hash": "81fc4dd1dbd3dc5c2ae7a1a459dac8df",
+    "hash": "456f1a54592e2fcad989096b6de4a5c6",
+    "content-hash": "023d9ade1c276d12d965da8c342d111f",
     "packages": [
         {
             "name": "apache/log4php",
@@ -39,16 +39,16 @@
         },
         {
             "name": "facebook/facebook-instant-articles-sdk-php",
-            "version": "v1.5.3",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/facebook-instant-articles-sdk-php.git",
-                "reference": "4210c2b78a4d28b0c56c0e8575db47d30e48ef54"
+                "reference": "f18461923e17af6f05120c687c9f20a540f3d420"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/facebook-instant-articles-sdk-php/zipball/4210c2b78a4d28b0c56c0e8575db47d30e48ef54",
-                "reference": "4210c2b78a4d28b0c56c0e8575db47d30e48ef54",
+                "url": "https://api.github.com/repos/facebook/facebook-instant-articles-sdk-php/zipball/f18461923e17af6f05120c687c9f20a540f3d420",
+                "reference": "f18461923e17af6f05120c687c9f20a540f3d420",
                 "shasum": ""
             },
             "require": {
@@ -86,20 +86,20 @@
                 "instant",
                 "sdk"
             ],
-            "time": "2016-11-29 15:38:03"
+            "time": "2017-07-27 19:19:51"
         },
         {
             "name": "facebook/graph-sdk",
-            "version": "5.4.2",
+            "version": "5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-graph-sdk.git",
-                "reference": "2839246e971aef150650196acbb46d47e5207370"
+                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/2839246e971aef150650196acbb46d47e5207370",
-                "reference": "2839246e971aef150650196acbb46d47e5207370",
+                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/2f9639c15ae043911f40ffe44080b32bac2c5280",
+                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280",
                 "shasum": ""
             },
             "require": {
@@ -144,7 +144,7 @@
                 "facebook",
                 "sdk"
             ],
-            "time": "2016-11-15 14:34:16"
+            "time": "2017-08-16 17:28:07"
         },
         {
             "name": "mihaeu/html-formatter",
@@ -188,25 +188,25 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.2.0",
+            "version": "v3.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "e1241f275814827c411d922ba8e64cf2a00b2994"
+                "reference": "c5f5263ed231f164c58368efbce959137c7d9488"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/e1241f275814827c411d922ba8e64cf2a00b2994",
-                "reference": "e1241f275814827c411d922ba8e64cf2a00b2994",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/c5f5263ed231f164c58368efbce959137c7d9488",
+                "reference": "c5f5263ed231f164c58368efbce959137c7d9488",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -237,7 +237,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03 08:11:03"
+            "time": "2017-07-29 21:54:42"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
This is a really useful tool, but the current version is getting errors because of updated transformer rules in newer versions of the SDK (one of them is `FooterSmallRule`). I updated the version in composer, and rebuilding the Docker container it worked locally. 

Let me know if there's anything I should change about this, and it would be great to see the live version working!